### PR TITLE
Adjust ternary axis ticks to display log range

### DIFF
--- a/ternary_plot_example.py
+++ b/ternary_plot_example.py
@@ -108,8 +108,12 @@ def plot_ternary_scatter(
         linewidths=0.5,
     )
 
-    # Configure ticks and labels
-    tax.ticks(axis="lbr", linewidth=1, multiple=0.2, offset=0.02, fontsize=10)
+    # Configure ticks and labels with logarithmic-style values from 10^3 to 10^9
+    exponents = range(3, 10)
+    tick_positions = np.linspace(0.0, 1.0, num=len(exponents))
+    tick_labels = [fr"$10^{{{exp}}}$" for exp in exponents]
+    custom_ticks = list(zip(tick_positions, tick_labels))
+    tax.ticks(axis="lbr", ticks=custom_ticks, linewidth=1, offset=0.02, fontsize=10)
     tax.left_axis_label("Molécula A", offset=0.12, fontsize=12)
     tax.right_axis_label("Molécula B", offset=0.12, fontsize=12)
     tax.top_axis_label("Molécula C", offset=0.12, fontsize=12)


### PR DESCRIPTION
## Summary
- replace the default ternary ticks with custom tick labels covering the 10^3 to 10^9 range on each axis

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1731e3798832ea1812157c81e7e3e